### PR TITLE
Add verification script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,15 @@ npm run dist
 ```
 
 The compiled files will be produced using `electron-builder`.
+
+## Verification
+
+To verify that the application builds and launches correctly in production mode,
+run:
+
+```bash
+npm run verify
+```
+
+This script builds the React application and starts Electron in a headless
+environment for a few seconds to ensure no startup errors occur.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "dev": "concurrently -k \"npm run start:react\" \"npm run start:electron\"",
     "build": "npm --prefix app run build",
     "pack": "npm run build && electron-builder --dir",
-    "dist": "npm run build && electron-builder"
+    "dist": "npm run build && electron-builder",
+    "verify": "node scripts/verify.js",
+    "test": "npm run verify"
   },
   "dependencies": {
     "electron": "^30.0.1"

--- a/scripts/verify.js
+++ b/scripts/verify.js
@@ -1,0 +1,47 @@
+const { spawn } = require('child_process');
+
+function run(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(command, args, { stdio: 'inherit', ...options });
+    proc.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`${command} exited with code ${code}`));
+      }
+    });
+  });
+}
+
+(async () => {
+  try {
+    console.log('\nBuilding React application...');
+    await run('npm', ['run', 'build']);
+
+    console.log('\nLaunching Electron application...');
+    const env = { ...process.env, NODE_ENV: 'production' };
+    const electronArgs = ['-a', 'npx', 'electron', '.', '--no-sandbox'];
+    const electron = spawn('xvfb-run', electronArgs, { env, stdio: 'inherit' });
+
+    const timeout = setTimeout(() => {
+      electron.kill('SIGTERM');
+    }, 5000);
+
+    await new Promise((resolve, reject) => {
+      electron.on('exit', (code, signal) => {
+        clearTimeout(timeout);
+        if (code === 0 || signal === 'SIGTERM') {
+          resolve();
+        } else {
+          reject(new Error(`Electron exited with code ${code}`));
+        }
+      });
+      electron.on('error', reject);
+    });
+
+    console.log('Verification succeeded.');
+  } catch (err) {
+    console.error(err.message);
+    process.exit(1);
+  }
+})();


### PR DESCRIPTION
## Summary
- add a `verify` command that builds and briefly launches Electron
- document the new verification command in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6855fd7332a08322926e7a05613cc84f