### PR TITLE
Fix app deps installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Flight Simulator.
 
 ## Development
 
-Install dependencies and start the development environment:
+Install dependencies and start the development environment. Running `npm install`
+in the project root also installs packages for the React front‑end located in the
+`app` directory:
 
 ```bash
 npm install
@@ -15,6 +17,10 @@ npm run dev
 
 This command runs the React development server and launches Electron once the
 app is available on <http://localhost:5173>.
+
+The root `npm install` triggers a `postinstall` step that installs the React
+dependencies in `app`. If you skip that step, run `npm install` inside
+`app` manually.
 
 ## Building
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "electron-app",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "electron": "^30.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "pack": "npm run build && electron-builder --dir",
     "dist": "npm run build && electron-builder",
     "verify": "node scripts/verify.js",
-    "test": "npm run verify"
+    "test": "npm run verify",
+    "postinstall": "npm --prefix app install"
   },
   "dependencies": {
     "electron": "^30.0.1"


### PR DESCRIPTION
## Summary
- ensure `npm install` installs the React dependencies
- clarify install steps in the README

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685600fbcef4832296fc15ae0214be2a