### PR TITLE
Add Active Flights page with routing

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@shadcn/ui": "^0.0.4",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-router-dom": "^6.23.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -1069,6 +1070,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -3423,6 +3433,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/readable-stream": {

--- a/app/package.json
+++ b/app/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@shadcn/ui": "^0.0.4",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-router-dom": "^6.23.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/app/src/ActiveFlights.tsx
+++ b/app/src/ActiveFlights.tsx
@@ -1,0 +1,42 @@
+
+interface Flight {
+  id: number;
+  pilot: string;
+  origin: string;
+  destination: string;
+  aircraft: string;
+}
+
+const flights: Flight[] = [
+  { id: 1, pilot: 'John Doe', origin: 'KJFK', destination: 'KLAX', aircraft: 'B737' },
+  { id: 2, pilot: 'Jane Smith', origin: 'EGLL', destination: 'EHAM', aircraft: 'A320' },
+  { id: 3, pilot: 'Bob Brown', origin: 'KSEA', destination: 'CYYZ', aircraft: 'B777' },
+];
+
+export default function ActiveFlights() {
+  return (
+    <div className="ActiveFlights">
+      <h1>Active Flights</h1>
+      <table>
+        <thead>
+          <tr>
+            <th>Pilot</th>
+            <th>Origin</th>
+            <th>Destination</th>
+            <th>Aircraft</th>
+          </tr>
+        </thead>
+        <tbody>
+          {flights.map((flight) => (
+            <tr key={flight.id}>
+              <td>{flight.pilot}</td>
+              <td>{flight.origin}</td>
+              <td>{flight.destination}</td>
+              <td>{flight.aircraft}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,4 +1,6 @@
 import "./App.css";
+import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
+import ActiveFlights from "./ActiveFlights";
 
 interface AcarsMessage {
   id: number;
@@ -28,7 +30,7 @@ const dummyData: AcarsMessage[] = [
   }
 ];
 
-function App() {
+function Home() {
   return (
     <div className="App">
       <h1>Electron ACARS Viewer</h1>
@@ -51,6 +53,27 @@ function App() {
         </tbody>
       </table>
     </div>
+  );
+}
+
+function App() {
+  return (
+    <Router>
+      <nav>
+        <ul>
+          <li>
+            <Link to="/">Home</Link>
+          </li>
+          <li>
+            <Link to="/active-flights">Active Flights</Link>
+          </li>
+        </ul>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/active-flights" element={<ActiveFlights />} />
+      </Routes>
+    </Router>
   );
 }
 


### PR DESCRIPTION
## Summary
- add react-router for navigation
- create Active Flights page to show dummy flight data

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6856150b9d9c832298d8addfe20f1800